### PR TITLE
fix(InlinePlaceTagAdmin): guard against None parent_object

### DIFF
--- a/src/sa_api_v2/admin.py
+++ b/src/sa_api_v2/admin.py
@@ -393,9 +393,10 @@ class InlinePlaceTagAdmin(admin.StackedInline):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "tag":
-            kwargs["queryset"] = models.Tag.objects.filter(
-                dataset=self.parent_obj.dataset
-            )
+            if self.parent_obj is not None:
+                kwargs["queryset"] = models.Tag.objects.filter(
+                    dataset=self.parent_obj.dataset
+                )
             return super(InlinePlaceTagAdmin, self).formfield_for_foreignkey(
                 db_field, request, **kwargs
             )


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/381

When adding a new Place via the admin panel the expected `parent_object` of the Place's tags is `None` since the Place has not been created yet. This PR guards against a `None` `parent_object`.

See also: https://docs.djangoproject.com/en/3.0/ref/contrib/admin/#django.contrib.admin.InlineModelAdmin.get_formset